### PR TITLE
fix: cant dismiss alert 

### DIFF
--- a/Sources/AlertKit/Extensions/SwiftUIExtension.swift
+++ b/Sources/AlertKit/Extensions/SwiftUIExtension.swift
@@ -1,16 +1,29 @@
 import SwiftUI
+import UIKit
 
 @available(iOS 13.0, *)
 extension View {
-    
-    public func alert(isPresent: Binding<Bool>, view: AlertViewProtocol, completion: (()->Void)? = nil) -> some View {
-        if isPresent.wrappedValue {
-            let wrapperCompletion = {
-                isPresent.wrappedValue = false
-                completion?()
-            }
-            if let window = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first {
-                view.present(on: window, completion: wrapperCompletion)
+
+    public func alert(
+        isPresent: Binding<Bool>,
+        view: AlertViewProtocol,
+        completion: (() -> Void)? = nil
+    ) -> some View {
+        // Perform side effects asynchronously to avoid state changes during view updates
+        DispatchQueue.main.async {
+            if isPresent.wrappedValue {
+                let wrapperCompletion = {
+                    isPresent.wrappedValue = false
+                    completion?()
+                }
+                if let window = UIApplication.shared.windows.first(where: {
+                    $0.isKeyWindow
+                }) {
+                    view.present(on: window, completion: wrapperCompletion)
+                }
+            } else {
+                // Programmatically dismiss any active alerts when Binding flips to false
+                AlertKitAPI.dismissAllAlerts(completion: completion)
             }
         }
         return self

--- a/Sources/AlertKit/Views/AlertAppleMusic16View.swift
+++ b/Sources/AlertKit/Views/AlertAppleMusic16View.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 @available(iOS 13, *)
-public class AlertAppleMusic16View: UIView, AlertViewProtocol {
+public class AlertAppleMusic16View: UIView, AlertViewProtocol, AlertInternal, AlertViewInternalDismissProtocol {
     
     open var dismissByTap: Bool = true
     open var dismissInTime: Bool = true


### PR DESCRIPTION
## Goal
- AlertKitAPI.dismissAllAlerts only dismisses views conforming to AlertViewInternalDismissProtocol. AlertAppleMusic17View view conforms; AlertAppleMusic16View view does not
- .alert modifier not working as intended for loading type alert
